### PR TITLE
Allow URLs if player is mplayer

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,18 +14,23 @@ function Play(opts){
 
   this.players       = opts.players       || players
   this.player        = opts.player        || findExec(this.players)
+  this.urlRegex      = /^(https?|ftp):\/\/[^\s\/$.?#].[^\s]*$/i
+  // Regex by @stephenhay from https://mathiasbynens.be/demo/url-regex
 
   this.play = function(what, next){
-    next = next || function(){}
+    next  = next || function(){}
+    isURL = this.player == 'mplayer' && this.urlRegex.test(what)
+
+    try {
+      isFile = fs.statSync(what).isFile()
+    } catch (err){
+      isFile = false
+    }
 
     if (!what) return next(new Error("No audio file specified"));
 
-    try {
-      if (!fs.statSync(what).isFile()){
-        return next(new Error(what + " is not a file"));
-      }
-    } catch (err){
-      return next(new Error("File doesn't exist: " + what));
+    if (!isURL && !isFile){
+      return next(new Error(what + " is not a file or URL"))
     }
 
     if (!this.player){

--- a/tests.js
+++ b/tests.js
@@ -43,10 +43,9 @@ describe('error handling', function(){
     spy.callsArgWith(1, undefined, undefined, "file doesn't exist")
 
     player.play('beep.mp3', function(err){
-      expect(err.message).to.be("File doesn't exist: beep.mp3")
+      expect(err.message).to.be("beep.mp3 is not a file or URL")
       done()
     })
-  })
 
   it("throws errors if suitable audio tool couldn't be found", function(done){
     var cli = require('./')({ players: [] })

--- a/tests.js
+++ b/tests.js
@@ -46,6 +46,7 @@ describe('error handling', function(){
       expect(err.message).to.be("beep.mp3 is not a file or URL")
       done()
     })
+  })
 
   it("throws errors if suitable audio tool couldn't be found", function(done){
     var cli = require('./')({ players: [] })


### PR DESCRIPTION
mplayer supports URLs, so in the cases where mplayer is the selected player, play-sound should also support URLs.

- update logic to check for files AND URL format
- update test assertion to account for new error language

Fixes #7 