### PR TITLE
Add omxplayer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var fs               = require('fs')
                         'afplay',
                         'mpg123',
                         'mpg321',
-                        'play'
+                        'play',
+                        'omxplayer'
                        ]
 
 function Play(opts){


### PR DESCRIPTION
This commit adds the `omxplayer` to the default list of players. `omxplayer` is installed by default on the Raspberry Pi.