### PR TITLE
Adding support for player args and returning the process

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ player.play('foo.mp3', { afplay: ['-v', 1 ] /* lower volume for afplay on OSX */
 
 // access the node child_process in case you need to kill it on demand
 var audio = player.play('foo.mp3', function(err){
-  if (err) throw err
+  if (err && !err.killed) throw err
 })
 // ...
 audio.kill()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ player.play('foo.mp3', function(err){
 player.play('foo.mp3', { timeout: 300 }, function(err){  // opts will be passed to child process
   if (err) throw err
 })
+
+// configure arguments for executable if any
+player.play('foo.mp3', { afplay: ['-v', 1 ] /* lower volume for afplay on OSX */ }, function(err){
+  if (err) throw err
+})
+
+// access the node child_process in case you need to kill it on demand
+var audio = player.play('foo.mp3', function(err){
+  if (err) throw err
+})
+// ...
+audio.kill()
 ```
 
 ## options

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ function Play(opts){
   this.play = function(what, options, next){
     next  = next || function(){}
     next  = typeof(options) === 'function' ? options : next
+    options = options || {}
+
     var isURL = this.player == 'mplayer' && this.urlRegex.test(what)
 
     if (!what) return next(new Error("No audio file specified"));

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ function Play(opts){
       return next(new Error("Couldn't find a suitable audio player"))
     }
 
-    child_process.execFile(this.player, [what], options, function(err, stdout, stderr){
+    var args = Array.isArray(options[this.player]) ? options[this.player].concat(what) : [what]
+    return child_process.execFile(this.player, args, options, function(err, stdout, stderr){
       next(err && !err.killed ? err : undefined);
     })
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "mocha": "^1.21.4",
-    "mock-fs": "^2.3.1",
+    "mock-fs": "^3.11.0",
     "proxyquire": "^1.0.1",
     "sinon": "^1.10.3"
   },

--- a/tests.js
+++ b/tests.js
@@ -71,6 +71,28 @@ describe("overridable options", function(){
     expect(spy.calledWith("foo", ["beep.mp3"])).to.be(true)
   })
 
+  it("takes player arguments", function(){
+    var spy = sinon.stub()
+      , cli = proxyquire('./', { child_process: { execFile: spy }})({player: "afplay"})
+    mock({"beep.mp3": ""})
+
+    cli.play("beep.mp3", { afplay: ["-v", 2] })
+
+    expect(spy.calledOnce).to.be(true)
+    expect(spy.calledWith("afplay", ["-v", 2, "beep.mp3"])).to.be(true)
+  })
+
+  it("returns the child_process instance", function(){
+    var returnInstance = {}
+      , spy = sinon.stub().returns(returnInstance)
+      , cli = proxyquire('./', { child_process: { execFile: spy }})({player: "foo"})
+    mock({"beep.mp3": ""})
+
+    var response = cli.play("beep.mp3")
+
+    expect(response).to.equal(returnInstance)
+  })
+
 })
 
 if (!process.env.CI){


### PR DESCRIPTION
Two things:

1. Player args. This way, the user can supply optional arguments per player via `{ afplay: ['-v', 1] }` (to control volume)
2. Return `child_process`. This way the user can issue a `kill()` if they want to end early