### PR TITLE
Add ffplay and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ audio.kill()
 * `players` – List of available audio players to check. Default:
   * [`mplayer`](https://www.mplayerhq.hu/)
   * [`afplay`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/afplay.1.html)
+  * [`ffplay`](https://ffmpeg.org/ffplay.html)
   * [`mpg123`](http://www.mpg123.de/)
   * [`mpg321`](http://mpg321.sourceforge.net/)
   * [`play`](http://sox.sourceforge.net/)

--- a/README.md
+++ b/README.md
@@ -10,28 +10,34 @@ Play sounds by shelling out to one of the available audio players.
 
 ## Examples
 
-```javascript
-var player = require('play-sound')(opts = {})
+```js
+const player = require('play-sound')()
 
-// $ mplayer foo.mp3 
-player.play('foo.mp3', function(err){
+// $ mplayer foo.mp3
+player.play('foo.mp3', err => {
   if (err) throw err
 })
 
 // { timeout: 300 } will be passed to child process
-player.play('foo.mp3', { timeout: 300 }, function(err){
+player.play('foo.mp3', { timeout: 300 }, err => {
   if (err) throw err
 })
 
 // configure arguments for executable if any
-player.play('foo.mp3', { afplay: ['-v', 1 ] /* lower volume for afplay on OSX */ }, function(err){
+player.play('foo.mp3', { afplay: ['-v', 1 ] /* lower volume for afplay on OSX */ }, err => {
   if (err) throw err
 })
 
 // access the node child_process in case you need to kill it on demand
-var audio = player.play('foo.mp3', function(err){
-  if (err && !err.killed) throw err
+const audio = player.play('foo.mp3', (err, result) => {
+  if (result) {
+    console.log(result.code, result.signal, result.killed)
+  }
+  if (err && !err.killed) {
+    throw err
+  }
 })
+
 audio.kill()
 ```
 

--- a/index.js
+++ b/index.js
@@ -31,11 +31,9 @@ function Play(opts){
     options = Object.assign(defaultOptions, typeof options === 'object' ? options : {})
     options.stdio = 'ignore'
 
-    var isURL = this.player == 'mplayer' && this.urlRegex.test(what)
-
     if (!what) return next(new Error("No audio file specified"))
 
-    if (!this.player){
+    if (!this.player || this.urlRegex.test(what) && this.player !== 'mplayer') {
       return next(new Error("Couldn't find a suitable audio player"))
     }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var path             = require('path')
+var fs               = require('fs')
+  , path             = require('path')
   , findExec         = require('find-exec')
   , spawn            = require('child_process').spawn
   , players          = [
@@ -32,6 +33,12 @@ function Play(opts){
     options.stdio = 'ignore'
 
     if (!what) return next(new Error("No audio file specified"))
+
+    try {
+      fs.accessSync(what, fs.constants.R_OK)
+    } catch (_) {
+      return next(new Error("Specified file can't be accessed"))
+    }
 
     if (!this.player || this.urlRegex.test(what) && this.player !== 'mplayer') {
       return next(new Error("Couldn't find a suitable audio player"))

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs               = require('fs')
   , players          = [
                         'mplayer',
                         'afplay',
+                        'ffplay',
                         'mpg123',
                         'mpg321',
                         'play',
@@ -11,6 +12,10 @@ var fs               = require('fs')
                         'aplay',
                         'cmdmp3'
                        ]
+
+var defaultOptions = {
+  ffplay: ['-nodisp', '-autoexit']
+}
 
 function Play(opts){
   opts               = opts               || {}
@@ -23,7 +28,7 @@ function Play(opts){
   this.play = function(what, options, next){
     next  = next || function(){}
     next  = typeof options === 'function' ? options : next
-    options = typeof options === 'object' ? options : {}
+    options = Object.assign(defaultOptions, typeof options === 'object' ? options : {})
     options.stdio = 'ignore'
 
     var isURL = this.player == 'mplayer' && this.urlRegex.test(what)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var fs               = require('fs')
+var path             = require('path')
   , findExec         = require('find-exec')
   , spawn            = require('child_process').spawn
   , players          = [
@@ -47,7 +47,7 @@ function Play(opts){
     return process
   }
 
-  this.test = function(next) { this.play('./assets/test.mp3', next) }
+  this.test = function(next) { this.play(path.join(__dirname, 'assets', 'test.mp3'), next) }
 }
 
 module.exports = function(opts){

--- a/tests.js
+++ b/tests.js
@@ -7,7 +7,8 @@ describe('mplayer has the maximum priority', function(){
   var spy, cli
 
   beforeEach(function(){
-    spy = sinon.stub()
+    var returnInstance = {on: function() {}}
+    spy = sinon.stub().returns(returnInstance)
     cli = proxyquire('./', { child_process: { spawn: spy }})()
 
     mock({
@@ -61,7 +62,8 @@ describe("overridable options", function(){
   })
 
   it("player has precedence over players", function(){
-    var spy = sinon.stub()
+    var returnInstance = {on: function() {}}
+      , spy = sinon.stub().returns(returnInstance)
       , cli = proxyquire('./', { child_process: { spawn: spy }})({player: "foo"})
     mock({"beep.mp3": ""})
 
@@ -72,7 +74,8 @@ describe("overridable options", function(){
   })
 
   it("takes player arguments", function(){
-    var spy = sinon.stub()
+    var returnInstance = {on: function() {}}
+      , spy = sinon.stub().returns(returnInstance)
       , cli = proxyquire('./', { child_process: { spawn: spy }})({player: "afplay"})
     mock({"beep.mp3": ""})
 


### PR DESCRIPTION
Added [ffplay](https://ffmpeg.org/ffplay.html) player, which is part of ffmpeg. On one system I don't have any of the CLI players installed, yet there is already ffmpeg with `ffplay`.

Also some fixes:

- `isURL` was unused, I think it supposed to error if `what` is a URL and `player` isn't `mplayer`.
- `test` was using relative path, so it won't work outside of the package directory.
- Checking if file exists and can be accessed.
- Child process handling as per https://nodejs.org/api/child_process.html. Also addresses https://github.com/shime/play-sound/issues/23.