### PR TITLE
feat: allow playing on windows with powershell

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var fs               = require('fs')
                         'play',
                         'omxplayer',
                         'aplay',
-                        'cmdmp3'
+                        'cmdmp3',
+                        'powershell'
                        ]
 
 function Play(opts){


### PR DESCRIPTION
For some reason, I was getting an error saying `Couldn't find a suitable audio player` every time I tried to play a sound on Windows. This fixes it.