### PR TITLE
feat:Allow concatenation of parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function Play(opts){
       return next(new Error("Couldn't find a suitable audio player"))
     }
 
-    var args = Array.isArray(options[this.player]) ? options[this.player].concat(what) : [what]
+    var args = Array.isArray(options[this.player]) ? [what].concat(options[this.player]) : [what]
     var process = spawn(this.player, args, options)
     if (!process) {
       next(new Error("Unable to spawn process with " + this.player))


### PR DESCRIPTION
With this change calls to the player that passes multiple arguments such as `trim` and `vol` will be accepted and interpreted by the player.

`audio = playSound.play(
            filePath,
            {
                play: ['trim', TRIM_SECONDS, 'vol', VOLUME_LEVEL]
            },
            (err: any) => {
                if (err) {
                   return;
                }
            });`